### PR TITLE
Update click types - Add ButtonSingleClick, ButtonDoubleClick, ButtonHold

### DIFF
--- a/MMM-flicio.js
+++ b/MMM-flicio.js
@@ -30,7 +30,7 @@ Module.register("MMM-flicio", {
     if (this.config.buttons[payload.bdAddr]) {
       let button = this.config.buttons[payload.bdAddr];
       let messages;
-      if (notification == "buttonUpOrDown") {
+      if (notification == "buttonSingleOrDoubleClickOrHold") {
         messages = button[payload.clickType];
       } else if (
         notification == "connectionStatusChanged" &&

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Before adding the `config` parameter you should first register your buttons. Thi
 The `config` attribute has 3 parameters:
 
 * `allowQueued`: can be `true` or `false`. When `false` all button inputs that couldn't be delivered within `queueTimeout` seconds will be discarded. `true` by default.
-* `queueTimeout`: number of seconds to wait when `allowQueued` is `false`. Is ignored when `alllowQueued` is `true`. `5` by default.
-* `buttons`: an Object with as key the MAC addresses of the buttons and as value another Object. This Object has as key as String describing the button action, either `'ButtonDown'` or `'ButtonUp'`. The value of this Object is a list of Objects containing `notification` (a String) with the notification and `payload` (Any Type, optionally) the payload that should be sent together with that notification.
+* `queueTimeout`: number of seconds to wait when `allowQueued` is `false`. Is ignored when `allowQueued` is `true`. `5` by default.
+* `buttons`: an Object with as key the MAC addresses of the buttons and as value another Object. This Object has as key as String describing the button action, either `'ButtonSingleClick'`, `'ButtonDoubleClick'`, or `'ButtonHold'`. The value of this Object is a list of Objects containing `notification` (a String) with the notification and `payload` (Any Type, optionally) the payload that should be sent together with that notification.
 
 An example of a module entry:
 
@@ -29,7 +29,7 @@ An example of a module entry:
 		allowQueued: false,
 		buttons: {
 			"AA:BB:CC:DD:EE:FF": {
-				ButtonDown: [
+				ButtonSingleClick: [
 					{
 						notification: "DO-SOMETHING",
 						payload: {
@@ -43,10 +43,23 @@ An example of a module entry:
 				]
 			},
 			"11:22:33:44:55:66": {
-				ButtonUp: [
+				ButtonSingleClick: [
 					{
 						notification: "DO-SOMETHING-COOL",
 						payload: "foo"
+					}
+				],
+				ButtonDoubleClick: [
+					{
+						notification: "DO-SOMETHING-ELSE-COOL",
+						payload: {
+							foo: "bar"
+						}
+					}
+				],
+				ButtonHold: [
+					{
+						notification: "DO-SOMETHING-EXTRA-COOL"
 					}
 				]
 			}

--- a/node_helper.js
+++ b/node_helper.js
@@ -27,8 +27,8 @@ module.exports = NodeHelper.create({
     let cc = new FlicConnectionChannel(bdAddr);
     this.client.addConnectionChannel(cc);
     let parent = this;
-    cc.on("buttonUpOrDown", function(clickType, wasQueued, timeDiff) {
-      parent.sendSocketNotification("buttonUpOrDown", {
+    cc.on("buttonSingleOrDoubleClickOrHold", function(clickType, wasQueued, timeDiff) {
+      parent.sendSocketNotification("buttonSingleOrDoubleClickOrHold", {
         bdAddr: bdAddr,
         clickType: clickType,
         wasQueued: wasQueued,
@@ -61,6 +61,8 @@ module.exports = NodeHelper.create({
     return new Promise(resolve => {
       flicd.stderr.on("data", data => {
         // wait for flicd to finish launching
+        // log status of flicd, specifically to debug pm2 issues
+        console.log("Flicd launched.", data.toString());
         if (
           data
             .toString()


### PR DESCRIPTION
- Swap `buttonUpOrDown` events with `buttonSingleOrDoubleClickOrHold` events
- Swap listeners for `buttonUpOrDown` events with `buttonSingleOrDoubleClickOrHold` listeners
- Update README.md to reflect new click actions

Note: Unable to update example.js to reflect new `buttonSingleOrDoubleClickOrHold` listener as it is a subproject

Note: if using MagicMirror with pm2 a permissions issue arises while trying to start the daemon, was able to solve it after console logging at the daemon startup stage.

The error will be thrown on line 65 of node_helper.js but will not show in any logs. Added a console log at this stage to debug easier, viewing pm2 logs points out the issue quickly.